### PR TITLE
IsPositive() treats zero as a positive number

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,10 @@ test/
 
     Essentially `AveragePooling2D` with a constant scaling of `poolSize*poolSize`. This is preferred in circom to preserve precision and reduce computation.
 
+- `util.circom`
+
+    `IsPositive()` treats zero as a positive number for better performance. If you want to use `IsPositive()` to check if a number is strictly positive, you can use the version in the in-code comments.
+
 ## Weights and biases scaling:
 - Circom only accepts integers as signals, but Tensorflow weights and biases are floating-point numbers.
 - In order to simulate a neural network in Circom, weights must be scaled up by `10**m` times. The larger `m` is, the higher the precision.

--- a/circuits/util.circom
+++ b/circuits/util.circom
@@ -20,6 +20,29 @@ template IsNegative() {
     out <== sign.sign;
 }
 
+/* Currently, IsPositive() treats zero as a positive number for better performance. 
+   The following is the correct version which output is 1 when the signal in is a positive number, 0 when it is zero or a negative number
+
+template IsPositive() {
+    signal input in;
+    signal output out;
+
+    component num2Bits = Num2Bits(254);
+    num2Bits.in <== in;
+    component sign = Sign();
+    
+    for (var i = 0; i < 254; i++) {
+        sign.in[i] <== num2Bits.out[i];
+    }
+    
+    component isz = IsZero();
+    isz.in <== in;
+    
+
+    out <== (1 - sign.sign) * (1 - isz.out);
+}
+*/
+
 template IsPositive() {
     signal input in;
     signal output out;


### PR DESCRIPTION
`IsPositive()` treats zero as a positive number for better performance. I added a correct version whose output is 1 when the signal in is a positive number, and 0 when it is zero or a negative number.

Found by UCSB using [Coda](https://github.com/Veridise/Coda).